### PR TITLE
feat: `unifont(cache = TRUE)`

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,7 +29,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Authors@R: c(person("Trevor L.", "Davis", role=c("aut", "cre"),
              comment = c(ORCID = "0000-0001-6341-4639")),
              person("GNU Unifont authors", role = "cph"))
 Description: Contains most of the hex font files from the 'GNU Unifont Project' <https://unifoundry.com/unifont/> compressed by 'xz'.  'GNU Unifont' is a duospaced bitmap font that attempts to cover all the official Unicode glyphs plus several of the artificial scripts in the '(Under-)ConScript Unicode Registry' <http://www.kreativekorp.com/ucsur/>.  Provides a convenience function for loading in several of them at the same time as a 'bittermelon' bitmap font object for easy rendering of the glyphs in an 'R' terminal or graphics device.
-URL: https://github.com/trevorld/hexfont
+URL: https://github.com/trevorld/hexfont, https://trevorldavis.com/R/hexfont/
 BugReports: https://github.com/trevorld/hexfont/issues
 License: GPL (>= 2)
 Depends: R (>= 4.0.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: hexfont
 Type: Package
 Title: 'GNU Unifont' Hex Fonts
-Version: 0.4.0
-Authors@R: c(person("Trevor L", "Davis", role=c("aut", "cre"),
+Version: 0.5.0-1
+Authors@R: c(person("Trevor L.", "Davis", role=c("aut", "cre"),
              email="trevor.l.davis@gmail.com",
              comment = c(ORCID = "0000-0001-6341-4639")),
              person("GNU Unifont authors", role = "cph"))
@@ -10,9 +10,10 @@ Description: Contains most of the hex font files from the 'GNU Unifont Project' 
 URL: https://github.com/trevorld/hexfont
 BugReports: https://github.com/trevorld/hexfont/issues
 License: GPL (>= 2)
-Imports: bittermelon (>= 1.1.2), utils
+Depends: R (>= 4.0.0)
+Imports: bittermelon (>= 1.1.2), tools, utils
 Suggests: knitr, oblicubes, rmarkdown, testthat, Unicode
 VignetteBuilder: knitr, rmarkdown
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+hexfont 0.5.0
+=============
+
+* `unifont()`'s new argument `cache` allows one to read/write precompiled versions of the fonts
+  from/to `tools::R_user_dir("hexfont", "cache")` (#8).
+  It is **much** faster to read such a cached pre-compiled font than recompile it from scratch.
+  `{hexfont}` now depends on R (>= 4.0.0) (which was when `tools::R_user_dir()` was introduced).
+
 hexfont 0.4.0
 =============
 

--- a/R/unifont.R
+++ b/R/unifont.R
@@ -8,7 +8,11 @@
 #' @param csur Include (Under-)Conscript Unicode Registry glyphs.
 #' @param sample Add circle to "Combining" characters.
 #' @inheritParams bittermelon::read_hex
+#' @param cache Use a cached version of this font from `tools::R_user_dir("hexfont", "cache")` if it exists.
+#'              If it does not exist than create a cached version of this font.
 #' @return A [bittermelon::bm_font()] object.
+#'         If `cache` is `TRUE` then as a side effect may create an `.rds` file
+#'         in `tools::R_user_dir("hexfont", "cache")`.
 #' @examples
 #' # Much faster to load only the subset of GNU Unifont one needs
 #' # Mandarin Chinese
@@ -26,9 +30,38 @@
 #'   bm <- as_bm_bitmap(s, font = font)
 #'   print(bm, px = px_ascii)
 #' }
+#'
+#' \donttest{# Will take more than 5s on CRAN machines
+#' # Compiling the entire font from the hex files takes a long time
+#' system.time({font <- unifont()})
+#' length(font) |> prettyNum(big.mark = ",") # number of glyphs
+#  object.size(font) |> format(units = "MB") # memory used
+#' # It is usually much faster to use a cached version of the font
+#' if (file.exists(hexfont:::unifont_cache_filename())) {
+#'   system.time({font_from_cache <- unifont(cache = TRUE)})
+#' }
+#' }
 #' @import bittermelon
 #' @export
-unifont <- function(upper = TRUE, jp = FALSE, csur = TRUE, sample = FALSE, ucp = NULL) {
+unifont <- function(upper = TRUE, jp = FALSE, csur = TRUE, sample = FALSE, ucp = NULL, cache = FALSE) {
+    stopifnot(is.null(ucp) || isFALSE(cache))
+    if (cache) {
+        f <- unifont_cache_filename(upper, jp, csur, sample)
+        if (file.exists(f)) {
+            font <- readRDS(f)
+        } else {
+            font <- unifont_from_hex(upper, jp, csur, sample)
+            if (!dir.exists(dirname(f)))
+                dir.create(dirname(f), recursive = TRUE)
+            saveRDS(font, file = f, version = 3)
+        }
+    } else {
+        font <- unifont_from_hex(upper, jp, csur, sample, ucp)
+    }
+    font
+}
+
+unifont_from_hex <- function(upper, jp, csur, sample, ucp = NULL) {
     f_base <- "unifont"
     if (jp) {
         f_base <- paste0(f_base, "_jp")
@@ -58,6 +91,14 @@ unifont <- function(upper = TRUE, jp = FALSE, csur = TRUE, sample = FALSE, ucp =
     }
     font
 }
+
+unifont_cache_filename <- function(upper = TRUE, jp = FALSE, csur = TRUE, sample = FALSE) {
+    cache_dir <- tools::R_user_dir("hexfont", "cache")
+    filename <- paste0("unifont_", unifont_version(), "_",
+                       sprintf("%d%d%d%d", upper, jp, csur, sample), ".rds")
+    normalizePath(file.path(cache_dir, filename), mustWork = FALSE)
+}
+
 
 #' GNU Unifont version number
 #'

--- a/README.Rmd
+++ b/README.Rmd
@@ -1,7 +1,7 @@
 # hexfont <img src="man/figures/logo.png" align="right" width="200px" alt="hexfont hex sticker">
 
 [![CRAN Status Badge](https://www.r-pkg.org/badges/version/hexfont)](https://cran.r-project.org/package=hexfont)
-[![R-CMD-check](https://github.com/trevorld/hexfont/workflows/R-CMD-check/badge.svg)](https://github.com/trevorld/hexfont/actions)
+[![R-CMD-check](https://github.com/trevorld/hexfont/actions/workflows/R-CMD-check.yaml/badge.svg?branch=main)](https://github.com/trevorld/hexfont/actions)
 
 ### Table of Contents
 
@@ -38,17 +38,17 @@ The main function `unifont()` loads in several GNU Unifont hex files at the same
 | csur | Include (Under-)Conscript Unicode Registry glyphs | `TRUE` |
 | sample | Add circle to "Combining" characters | `FALSE` | 
 | ucp | Character vector of Unicode Code Points to only load | `NULL` |
+| cache | Read/write a pre-compiled font from/to `tools::R_user_dir("hexfont", "cache")` | `FALSE` |
 
 ```{r unifont, output.class = "bitmap"}
-library("bittermelon") # remotes::install_github("trevorld/bittermelon")
-library("hexfont") # remotes::install_github("trevorld/hexfont")
+library("bittermelon")
+library("hexfont")
 system.time(font <- unifont()) # Unifont is a **big** font
 length(font) |> prettyNum(big.mark = ",") # number of glyphs
 object.size(font) |> format(units = "MB") # memory used
 
 # Faster to load from a cache
-saveRDS(font, "unifont.rds")
-system.time(font <- readRDS("unifont.rds"))
+system.time(font <- unifont(cache = TRUE))
 
 # Or just load the subset of GNU Unifont you need
 s <- "Ｒ很棒！"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hexfont <img src="man/figures/logo.png" align="right" width="200px" alt="hexfont hex sticker">
 
 [![CRAN Status Badge](https://www.r-pkg.org/badges/version/hexfont)](https://cran.r-project.org/package=hexfont)
-[![R-CMD-check](https://github.com/trevorld/hexfont/workflows/R-CMD-check/badge.svg)](https://github.com/trevorld/hexfont/actions)
+[![R-CMD-check](https://github.com/trevorld/hexfont/actions/workflows/R-CMD-check.yaml/badge.svg?branch=main)](https://github.com/trevorld/hexfont/actions)
 
 ### Table of Contents
 
@@ -23,7 +23,7 @@ source code distribution.  The version number is stripped from the file names in
 the hex fonts are all compressed by `xz` but other than that the hex fonts are otherwise unchanged.  Due to CRAN size limitations we omit the "precompiled" `unifont_all` hex file (this is presumably the concatenation of the "precompiled" `unifont` and `unifont_upper` hex files).
 
 
-```r
+``` r
 hex_dir <- system.file("font", package = "hexfont")
 list.files(hex_dir, pattern = ".hex.xz", recursive = TRUE)
 ```
@@ -84,34 +84,21 @@ The main function `unifont()` loads in several GNU Unifont hex files at the same
 | csur | Include (Under-)Conscript Unicode Registry glyphs | `TRUE` |
 | sample | Add circle to "Combining" characters | `FALSE` | 
 | ucp | Character vector of Unicode Code Points to only load | `NULL` |
+| cache | Read/write a pre-compiled font from/to `tools::R_user_dir("hexfont", "cache")` | `FALSE` |
 
 
-```r
-library("bittermelon") # remotes::install_github("trevorld/bittermelon")
-```
-
-```
-## 
-## Attaching package: 'bittermelon'
-```
-
-```
-## The following object is masked from 'package:base':
-## 
-##     which
-```
-
-```r
-library("hexfont") # remotes::install_github("trevorld/hexfont")
+``` r
+library("bittermelon")
+library("hexfont")
 system.time(font <- unifont()) # Unifont is a **big** font
 ```
 
 ```
 ##    user  system elapsed 
-##  96.170   0.103  96.292
+## 102.734   0.248 103.002
 ```
 
-```r
+``` r
 length(font) |> prettyNum(big.mark = ",") # number of glyphs
 ```
 
@@ -119,26 +106,25 @@ length(font) |> prettyNum(big.mark = ",") # number of glyphs
 ## [1] "123,234"
 ```
 
-```r
+``` r
 object.size(font) |> format(units = "MB") # memory used
 ```
 
 ```
-## [1] "189 Mb"
+## [1] "196.5 Mb"
 ```
 
-```r
+``` r
 # Faster to load from a cache
-saveRDS(font, "unifont.rds")
-system.time(font <- readRDS("unifont.rds"))
+system.time(font <- unifont(cache = TRUE))
 ```
 
 ```
 ##    user  system elapsed 
-##    0.65    0.00    0.65
+##   0.676   0.004   0.680
 ```
 
-```r
+``` r
 # Or just load the subset of GNU Unifont you need
 s <- "Ｒ很棒！"
 system.time(font_s <- unifont(ucp = str2ucp(s)))
@@ -146,10 +132,10 @@ system.time(font_s <- unifont(ucp = str2ucp(s)))
 
 ```
 ##    user  system elapsed 
-##   0.606   0.004   0.610
+##   0.645   0.000   0.646
 ```
 
-```r
+``` r
 # Mandarin Chinese
 as_bm_bitmap(s, font = font_s) |>
     bm_compress("v")
@@ -166,7 +152,7 @@ as_bm_bitmap(s, font = font_s) |>
 ##                    █  █▀     ▀▀    █      █
 ```
 
-```r
+``` r
 # Emoji
 as_bm_bitmap("🐭🐲🐵", font = font) |>
     bm_compress("v")
@@ -183,7 +169,7 @@ as_bm_bitmap("🐭🐲🐵", font = font) |>
 ##                   ▀▀▀     ▀▀▀
 ```
 
-```r
+``` r
 # Klingon
 as_bm_list("", font = font) |>
     bm_pad(type = "trim", left = 1L, right = 1L) |>
@@ -202,7 +188,7 @@ as_bm_list("", font = font) |>
 ## 
 ```
 
-```r
+``` r
 # Tengwar with combining glyphs
 bml <- as_bm_list("", font = font)
 to_raise <- which(names(bml) %in% c("U+E04A", "U+E04E"))

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,3 +2,5 @@ destination: "../../websites/R/hexfont/"
 url: "https://trevorldavis.com/R/hexfont"
 development:
     mode: auto
+template:
+  bootstrap: 5

--- a/man/unifont.Rd
+++ b/man/unifont.Rd
@@ -4,7 +4,14 @@
 \alias{unifont}
 \title{Load GNU Unifont font}
 \usage{
-unifont(upper = TRUE, jp = FALSE, csur = TRUE, sample = FALSE, ucp = NULL)
+unifont(
+  upper = TRUE,
+  jp = FALSE,
+  csur = TRUE,
+  sample = FALSE,
+  ucp = NULL,
+  cache = FALSE
+)
 }
 \arguments{
 \item{upper}{Include glyphs above the Unicode Basic Multilingual plane.}
@@ -17,9 +24,14 @@ unifont(upper = TRUE, jp = FALSE, csur = TRUE, sample = FALSE, ucp = NULL)
 
 \item{ucp}{Character vector of Unicode Code Points: glyphs not in this vector won't be read in.
 If \code{NULL} (default) read every glyph in the font.}
+
+\item{cache}{Use a cached version of this font from \code{tools::R_user_dir("hexfont", "cache")} if it exists.
+If it does not exist than create a cached version of this font.}
 }
 \value{
 A \code{\link[bittermelon:bm_font]{bittermelon::bm_font()}} object.
+If \code{cache} is \code{TRUE} then as a side effect may create an \code{.rds} file
+in \code{tools::R_user_dir("hexfont", "cache")}.
 }
 \description{
 The function \code{unifont()} loads in several GNU Unifont hex files as a
@@ -41,5 +53,15 @@ if (require("bittermelon")) {
   font <- unifont(ucp = str2ucp(s))
   bm <- as_bm_bitmap(s, font = font)
   print(bm, px = px_ascii)
+}
+
+\donttest{# Will take more than 5s on CRAN machines
+# Compiling the entire font from the hex files takes a long time
+system.time({font <- unifont()})
+length(font) |> prettyNum(big.mark = ",") # number of glyphs
+# It is usually much faster to use a cached version of the font
+if (file.exists(hexfont:::unifont_cache_filename())) {
+  system.time({font_from_cache <- unifont(cache = TRUE)})
+}
 }
 }

--- a/tests/testthat/test-unifont.R
+++ b/tests/testthat/test-unifont.R
@@ -8,7 +8,7 @@ test_that("unifont() works", {
         font <- unifont(ucp = str2ucp(s))
         bm <- as_bm_bitmap(s, font = font)
         print(bm)
-    })
+    }, unicode = TRUE)
 
     # Emoji
     verify_output("txt/emoji.txt", {
@@ -16,5 +16,5 @@ test_that("unifont() works", {
         font <- unifont(ucp = str2ucp(s))
         bm <- as_bm_bitmap(s, font = font)
         print(bm)
-    })
+    }, unicode = TRUE)
 })

--- a/vignettes/hexfont.Rmd
+++ b/vignettes/hexfont.Rmd
@@ -24,7 +24,13 @@ This is an R data package that includes most "hex" font files from the [GNU Unif
 source code distribution.  The version number is stripped from the file names in the `precompiled` directory and
 the hex fonts are all compressed by `xz` but other than that the hex fonts are otherwise unchanged.  Due to CRAN size limitations we omit the "precompiled" `unifont_all` hex file (this is presumably the concatenation of the "precompiled" `unifont` and `unifont_upper` hex files).
 
-
+```{css, echo=FALSE}
+pre,code {
+    font-family: Dejavu Sans Mono,FreeMono,monospace;
+    line-height: 1.0;
+    font-size: 100%;
+}
+```
 
 ```r
 hex_dir <- system.file("font", package = "hexfont")
@@ -87,25 +93,12 @@ The main function `unifont()` loads in several GNU Unifont hex files at the same
 | csur | Include (Under-)Conscript Unicode Registry glyphs | `TRUE` |
 | sample | Add circle to "Combining" characters | `FALSE` | 
 | ucp | Character vector of Unicode Code Points to only load | `NULL` |
+| cache | Read/write a pre-compiled font from/to `tools::R_user_dir("hexfont", "cache")` | `FALSE` |
 
 
 ```r
-library("bittermelon") # remotes::install_github("trevorld/bittermelon")
-```
-
-```
-## 
-## Attaching package: 'bittermelon'
-```
-
-```
-## The following object is masked from 'package:base':
-## 
-##     which
-```
-
-```r
-library("hexfont") # remotes::install_github("trevorld/hexfont")
+library("bittermelon")
+library("hexfont")
 system.time(font <- unifont()) # Unifont is a **big** font
 ```
 
@@ -132,8 +125,7 @@ object.size(font) |> format(units = "MB") # memory used
 
 ```r
 # Faster to load from a cache
-saveRDS(font, "unifont.rds")
-system.time(font <- readRDS("unifont.rds"))
+system.time(font <- unifont(cache = TRUE))
 ```
 
 ```


### PR DESCRIPTION
* `unifont()`'s new argument `cache` allows one to read/write precompiled versions of the fonts from/to `tools::R_user_dir("hexfont", "cache")` (#9). It is **much** faster to read such a cached pre-compiled font than recompile it from scratch. `{hexfont}` now depends on R (>= 4.0.0) (which was when `tools::R_user_dir()` was introduced).

closes #8