### PR TITLE
feat: `unifont(cache = getOption("unifont.cache", NULL))`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: hexfont
 Type: Package
 Title: 'GNU Unifont' Hex Fonts
-Version: 0.5.1
+Version: 1.0.0-0
 Authors@R: c(person("Trevor L.", "Davis", role=c("aut", "cre"),
              email="trevor.l.davis@gmail.com",
              comment = c(ORCID = "0000-0001-6341-4639")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+hexfont 1.0.0
+=============
+
+* Update examples to not use the R 4.1 pipe (so the package works on R 4.0) (#12).
+* `unifont()`'s `cache` argument now defaults to `getOption("unifont.cache", NULL)` and
+  if `cache = NULL` we now read in a cache file if it exists but if it does not
+  exist then we don't write a cache file.
+
 hexfont 0.5.1
 =============
 

--- a/R/unifont.R
+++ b/R/unifont.R
@@ -8,8 +8,13 @@
 #' @param csur Include (Under-)Conscript Unicode Registry glyphs.
 #' @param sample Add circle to "Combining" characters.
 #' @inheritParams bittermelon::read_hex
-#' @param cache Use a cached version of this font from `tools::R_user_dir("hexfont", "cache")` if it exists.
-#'              If it does not exist than create a cached version of this font.
+#' @param cache If `TRUE` read a cached version of this font from
+#'              `tools::R_user_dir("hexfont", "cache")` if it exists and
+#'              if it does not exist than create a cached version of this font.
+#'              If `FALSE` don't read or write a cached version of this font (even if it exists).
+#'              If `NULL` read a cached version of this font if it exists but if it
+#'              does not exist then don't create it.
+#'              This argument is ignored if `ucp` is not `NULL`.
 #' @return A [bittermelon::bm_font()] object.
 #'         If `cache` is `TRUE` then as a side effect may create an `.rds` file
 #'         in `tools::R_user_dir("hexfont", "cache")`.
@@ -33,9 +38,9 @@
 #'
 #' \donttest{# Will take more than 5s on CRAN machines
 #' # Compiling the entire font from the hex files takes a long time
-#' system.time({font <- unifont()})
-#' length(font) |> prettyNum(big.mark = ",") # number of glyphs
-#  object.size(font) |> format(units = "MB") # memory used
+#' system.time(font <- unifont(cache = FALSE))
+#' prettyNum(length(font), big.mark = ",") # number of glyphs
+#  format(object.size(font), units = "MB") # memory used
 #' # It is usually much faster to use a cached version of the font
 #' if (file.exists(hexfont:::unifont_cache_filename())) {
 #'   system.time({font_from_cache <- unifont(cache = TRUE)})
@@ -43,10 +48,12 @@
 #' }
 #' @import bittermelon
 #' @export
-unifont <- function(upper = TRUE, jp = FALSE, csur = TRUE, sample = FALSE, ucp = NULL, cache = FALSE) {
-    stopifnot(is.null(ucp) || isFALSE(cache))
+unifont <- function(upper = TRUE, jp = FALSE, csur = TRUE, sample = FALSE, ucp = NULL,
+                    cache = getOption("unifont.cache", NULL)) {
+    f <- unifont_cache_filename(upper, jp, csur, sample)
+    if (is.null(cache))
+        cache <- file.exists(f)
     if (cache) {
-        f <- unifont_cache_filename(upper, jp, csur, sample)
         if (file.exists(f)) {
             font <- readRDS(f)
         } else {

--- a/README.Rmd
+++ b/README.Rmd
@@ -43,7 +43,7 @@ The main function `unifont()` loads in several GNU Unifont hex files at the same
 ```{r unifont, output.class = "bitmap"}
 library("bittermelon")
 library("hexfont")
-system.time(font <- unifont()) # Unifont is a **big** font
+system.time(font <- unifont(cache = FALSE)) # Unifont is a **big** font
 length(font) |> prettyNum(big.mark = ",") # number of glyphs
 object.size(font) |> format(units = "MB") # memory used
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The main function `unifont()` loads in several GNU Unifont hex files at the same
 ``` r
 library("bittermelon")
 library("hexfont")
-system.time(font <- unifont()) # Unifont is a **big** font
+system.time(font <- unifont(cache = FALSE)) # Unifont is a **big** font
 ```
 
 ```

--- a/man/unifont.Rd
+++ b/man/unifont.Rd
@@ -10,7 +10,7 @@ unifont(
   csur = TRUE,
   sample = FALSE,
   ucp = NULL,
-  cache = FALSE
+  cache = getOption("unifont.cache", NULL)
 )
 }
 \arguments{
@@ -25,8 +25,13 @@ unifont(
 \item{ucp}{Character vector of Unicode Code Points: glyphs not in this vector won't be read in.
 If \code{NULL} (default) read every glyph in the font.}
 
-\item{cache}{Use a cached version of this font from \code{tools::R_user_dir("hexfont", "cache")} if it exists.
-If it does not exist than create a cached version of this font.}
+\item{cache}{If \code{TRUE} read a cached version of this font from
+\code{tools::R_user_dir("hexfont", "cache")} if it exists and
+if it does not exist than create a cached version of this font.
+If \code{FALSE} don't read or write a cached version of this font (even if it exists).
+If \code{NULL} read a cached version of this font if it exists but if it
+does not exist then don't create it.
+This argument is ignored if \code{ucp} is not \code{NULL}.}
 }
 \value{
 A \code{\link[bittermelon:bm_font]{bittermelon::bm_font()}} object.
@@ -57,8 +62,8 @@ if (require("bittermelon")) {
 
 \donttest{# Will take more than 5s on CRAN machines
 # Compiling the entire font from the hex files takes a long time
-system.time({font <- unifont()})
-length(font) |> prettyNum(big.mark = ",") # number of glyphs
+system.time(font <- unifont(cache = FALSE))
+prettyNum(length(font), big.mark = ",") # number of glyphs
 # It is usually much faster to use a cached version of the font
 if (file.exists(hexfont:::unifont_cache_filename())) {
   system.time({font_from_cache <- unifont(cache = TRUE)})

--- a/tests/testthat/test-unifont.R
+++ b/tests/testthat/test-unifont.R
@@ -1,6 +1,6 @@
 test_that("unifont() works", {
-
     skip_on_os("windows")
+    skip_if_not(l10n_info()[["UTF-8"]])
 
     # Mandarin Chinese
     verify_output("txt/mandarin.txt", {

--- a/vignettes/hexfont.Rmd
+++ b/vignettes/hexfont.Rmd
@@ -99,7 +99,7 @@ The main function `unifont()` loads in several GNU Unifont hex files at the same
 ```r
 library("bittermelon")
 library("hexfont")
-system.time(font <- unifont()) # Unifont is a **big** font
+system.time(font <- unifont(cache = FALSE)) # Unifont is a **big** font
 ```
 
 ```


### PR DESCRIPTION
* Update examples to not use the R 4.1 pipe (so the package works on R 4.0) (#12).
* `unifont()`'s `cache` argument now defaults to `getOption("unifont.cache", NULL)` and if `cache = NULL` we now read in a cache file if it exists but if it does not exist then we don't write a cache file.

closes #12